### PR TITLE
Allow options for preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Shareable babel presets to use across projects.
 }
 ```
 
+This preset uses [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) under the hood. To pass options down to that preset, you can pass an `env` option at the top level:
+```js
+{
+  // Will skip module transformations
+  presets: [['@launchpadlab/babel-preset', { env: { modules: false } }]],
+}
+```
+
 
 ## Migration Guides
 - [v2.0.0](migration-guides/v2.0.0.md)

--- a/es6.js
+++ b/es6.js
@@ -1,10 +1,10 @@
 // Technically es6+
 
-module.exports = function (api) {
+module.exports = function (api, options) {
   api.cache(true)
   return {
     'presets': [
-      '@babel/env',
+      ['@babel/env', options.env ],
     ],
     'plugins': [
       // Cherry-pick imports

--- a/es6.js
+++ b/es6.js
@@ -1,6 +1,6 @@
 // Technically es6+
 
-module.exports = function (api, options) {
+module.exports = function (api, options={}) {
   api.cache(true)
   return {
     'presets': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/babel-preset",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "index.js",
   "license": "MIT",
   "author": "dpikt",

--- a/react.js
+++ b/react.js
@@ -1,4 +1,4 @@
-module.exports = function (api, options) {
+module.exports = function (api, options={}) {
   api.cache(true)
   return {
     'presets': [

--- a/react.js
+++ b/react.js
@@ -1,8 +1,8 @@
-module.exports = function (api) {
+module.exports = function (api, options) {
   api.cache(true)
   return {
     'presets': [
-      require('./es6'),
+      [ require('./es6'), options ],
       '@babel/react',
     ],
     'plugins': [


### PR DESCRIPTION
AFAIK there's no way to override internal preset options at the config level, so we'll allow them to be passed down instead.

This will enable some cool things... 😁 